### PR TITLE
feat/FE: Store the `"staging"` to the `"environment"` attribution - To use the `World App simulator`⭕️

### DIFF
--- a/src/components/world-id/WorldIdVerification.tsx
+++ b/src/components/world-id/WorldIdVerification.tsx
@@ -321,6 +321,10 @@ export const WorldIdVerification = ({ onSuccess, onError }: WorldIdProps) => {
               preset={orbLegacy({ signal: callerAddress })}
               //preset={orbLegacy({ signal: userWalletAddress })}
 
+              // @dev - If you use the World App simulator (https://simulator.worldcoin.org/), you should set the environment to "staging"
+              environment="staging"
+              //environment="production"
+
               handleVerify={handleVerify}
 
               onSuccess={handleSuccess}


### PR DESCRIPTION
## World App simulator 

- https://simulator.worldcoin.org/
   <img width="1143" height="712" alt="Screenshot 2026-03-28 at 21 54 59" src="https://github.com/user-attachments/assets/9654c32e-cbc9-4096-9855-095f492fe585" />




<br>

## `environment="staging"`

- You can test during development using the [simulator](https://simulator.worldcoin.org/) and setting `environment` to `"staging"`.
   https://docs.world.org/world-id/idkit/integrate#step-4-generate-the-connect-url-and-collect-proof
   <img width="574" height="175" alt="Screenshot 2026-03-28 at 22 23 30" src="https://github.com/user-attachments/assets/1b623707-8a5e-4aae-9ccf-641c0d2fb59e" />

